### PR TITLE
Added PlayBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 ## Extensions and Utilities
 
 - [8th Wall](https://www.8thwall.com/docs/web/#getting-started-with-playcanvas) - Markerless AR runtime.
+- [PlayBuild](https://github.com/wearekuva/playbuild) - A integrated bundler and package manager with support for TypeScript & JSX
 - [playcanvas-ar](https://github.com/playcanvas/playcanvas-ar) - Marker-based AR solution built on ARTollkit.
 - [playcanvas-node](https://github.com/yushimatenjin/playcanvas-node) - REST API wrapper for Node.js.
 - [playcanvas-p2.js](https://github.com/playcanvas/playcanvas-p2.js) - An integration with the p2.js 2D physics engine.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@
 ## Extensions and Utilities
 
 - [8th Wall](https://www.8thwall.com/docs/web/#getting-started-with-playcanvas) - Markerless AR runtime.
-- [PlayBuild](https://github.com/wearekuva/playbuild) - A integrated bundler and package manager with support for TypeScript & JSX
 - [playcanvas-ar](https://github.com/playcanvas/playcanvas-ar) - Marker-based AR solution built on ARTollkit.
 - [playcanvas-node](https://github.com/yushimatenjin/playcanvas-node) - REST API wrapper for Node.js.
 - [playcanvas-p2.js](https://github.com/playcanvas/playcanvas-p2.js) - An integration with the p2.js 2D physics engine.
@@ -70,6 +69,7 @@
 - [playcanvas-vue](https://github.com/isobolewski/playcanvas-vue) - A PlayCanvas integration with Vue.js.
 - [tween.js](https://github.com/tweenjs/tween.js/) - Popular JavaScript tweening library that integrates easily with PlayCanvas.
 - [Pirron One](https://pic.pirron-rodon.one) - Editor externsions implementing post effects, terrain creation and more.
+- [PlayBuild](https://github.com/wearekuva/playbuild) - An integrated bundler and package manager with support for TypeScript & JSX.
 - [Sublime Completions](https://github.com/playcanvas/sublime-completions) - Sublime Text Autocompletion for the PlayCanvas API.
 
 ## Technical Demos


### PR DESCRIPTION
Added a link to PlayBuild. An in-editor compiler, bundler and package manager for the PlayCanvas code editor that adds support for Javascript Modules, TypeScript JSX and all the usual features of modern web tooling.