### PR TITLE
Add SplatMart to 3D Gaussian Splatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@
 - [Solaya](https://solaya.ai/) - Generate high-fidelity 3D digital twins as the foundation for unlimited visual assets.
 - [Splat Labs](https://www.splatlabs.ai/) - Capture, host and share immersive Gaussian splat digital twins.
 - [Splat3D](https://splat-3d.com/) - Browser-based platform for training and publishing splats.
+- [SplatMart](https://www.splatmart.com/) - Marketplace for buying and selling Gaussian splat scenes and assets.
 - [Splattr](https://splattr.app) - Create Gaussian splats on the cloud.
 - [SplatTour](https://splattour.com/) - Photorealistic 3D tours of any space, generated from a video shot with the user's phone.
 - [StorySplat](https://storysplat.com) - Transform your 3D captures into interactive stories.


### PR DESCRIPTION
SplatMart is a maintained marketplace for buying and selling Gaussian splat scenes and assets. Its listings use a PlayCanvas-based interactive viewer, so it fits the existing 3D Gaussian Splatting section alongside other platforms and galleries.